### PR TITLE
remove the checkout entirely

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@master
-      with:
-        clean: false
-      
     - name: Download SteamCMD
       shell: bash
       run: |


### PR DESCRIPTION
`actions/checkout` calls --force which removes local changes with remote origin I don't know how to rectify that other than remove it, it should be redundant in our usage anyway.
just let me do the funny with the version embed please ;_;